### PR TITLE
Fix build for python 3.9 and up

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython"]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, Extension
 import os
 try:
-    from Cython.Distutils import build_ext
+    from Cython.Build import cythonize
 except:
     use_cython = False
 else:
@@ -17,7 +17,6 @@ if use_cython:
             include_dirs = ["dubins/include"],
         )
     ]
-    cmdclass.update({ 'build_ext' : build_ext })
 else:
     ext_modules = [
         Extension("dubins",
@@ -56,6 +55,7 @@ setup(
         'Topic :: Scientific/Engineering :: Mathematics',
     ],
     cmdclass     = cmdclass,
-    ext_modules  = ext_modules,
+    ext_modules  = cythonize(ext_modules),
+    zip_safe=False,
 )
 


### PR DESCRIPTION
The build wasn't working for python 3.9 because `tp_print` was
deprecated but it was trying to use the already generated dubins.c file.
To fix this, I added a pyproject.toml file that guarantees that Cython
is available and I switched to using the `cythonize` call in order to
skip using a pre-generated `dubins/dubins.c` file.